### PR TITLE
epub:type: acknowledgements → acknowledgements

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -62,7 +62,7 @@
 	text-align: right;
 }
 
-[epub|type~="acknowledgements"]{
+[epub|type~="acknowledgments"]{
 	margin-top: 20vh;
 }
 

--- a/src/epub/text/acknowledgements.xhtml
+++ b/src/epub/text/acknowledgements.xhtml
@@ -6,7 +6,7 @@
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="frontmatter">
-		<section id="acknowledgements" epub:type="acknowledgements">
+		<section id="acknowledgements" epub:type="acknowledgments">
 			<p>To <abbr>Dr.</abbr> Paul H. DeKruif I am indebted not only for most of the bacteriological and medical material in this tale but equally for his help in the planning of the fable itself⁠—for his realization of the characters as living people, for his philosophy as a scientist. With this acknowledgement I want to record our months of companionship while working on the book, in the United States, in the West Indies, in Panama, in London and Fontainebleau. I wish I could reproduce our talks along the way, and the laboratory afternoons, the restaurants at night, and the deck at dawn as we steamed into tropic ports.</p>
 			<footer>
 				<p epub:type="z3998:signature">Sinclair Lewis</p>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -818,7 +818,7 @@
 					<a href="text/imprint.xhtml" epub:type="frontmatter imprint">Imprint</a>
 				</li>
 				<li>
-					<a href="text/acknowledgements.xhtml" epub:type="frontmatter acknowledgements">Acknowledgements</a>
+					<a href="text/acknowledgements.xhtml" epub:type="frontmatter acknowledgments">Acknowledgements</a>
 				</li>
 				<li>
 					<a href="text/halftitlepage.xhtml" epub:type="frontmatter halftitlepage">Half Title</a>


### PR DESCRIPTION
[source](https://idpf.github.io/epub-vocabs/structure/)

I only changed `epub:type`, and left other uses of “acknowledgements” unchanged.