### PR TITLE
Fix transcription error: e → ε

### DIFF
--- a/src/epub/text/chapter-36.xhtml
+++ b/src/epub/text/chapter-36.xhtml
@@ -97,7 +97,7 @@
 				<p>Holabird was as much bewildered as Tubbs would have been by the ramifications of Martin’s work. What did he think he was anyway⁠—a bacteriologist or a biophysicist? But Holabird was won by the scientific world’s reception of Martin’s first important paper, on the effect of X-rays, gamma rays, and beta rays on the anti-Shiga phage. It was praised in Paris and Brussels and Cambridge as much as in New York, for its insight and for “the clarity and to perhaps be unscientifically enthusiastic, the sheer delight and style of its presentation,” as Professor Berkeley Wurtz put it; which may be indicated by quoting the first paragraph of the paper:</p>
 				<blockquote>
 					<p>In a preliminary publication, I have reported a marked qualitative destructive effect of the radiations from radium emanations on Bacteriophage-anti-Shiga. In the present paper it is shown that X-rays, gamma rays, and beta rays produce identical inactivating effects on this bacteriophage. Furthermore, a quantitative relation is demonstrated to exist between this inactivation and the radiations that produce it. The results obtained from this quantitative study permit the statement that the percentage of inactivation, as measured by determining the units of bacteriophage remaining after irradiation by gamma and beta rays of a suspension of fixed virulence, is a function of the two variables, millicuries and hours. The following equation accounts quantitatively for the experimental results obtained:</p>
-					<m:math alttext="K = (λ × log⁡(e) × u_0 / u) / E_0 × (e − λ × t_1)">
+					<m:math alttext="K = (λ × log⁡(e) × u_0 / u) / E_0 × (ε − λ × t_1)">
 						<m:mi>K</m:mi>
 						<m:mo>=</m:mo>
 						<m:mfrac>
@@ -124,7 +124,7 @@
 								<m:mo>⁢</m:mo>
 								<m:mrow>
 									<m:mo>(</m:mo>
-									<m:mi>e</m:mi>
+									<m:mi>ε</m:mi>
 									<m:mo>−</m:mo>
 									<m:mi>λ</m:mi>
 									<m:msub>


### PR DESCRIPTION
(Split from #8 since this is a simple change unrelated to the manual.)

I found three modern ebooks that use epsilon instead of e in the denominator, including the PG Australia transcription; the audiobook narrated by John McDonough uses sigma for some reason. Whatever it is, [it certainly isn’t e](https://archive.org/details/lewis_arrowsmith_1925/page/406/mode/2up); I can believe that that scribble is an epsilon, and I can’t pull a sigma out of it no matter how I try, so epsilon it is.