### PR TITLE
Logarithm factor

### DIFF
--- a/src/epub/text/chapter-36.xhtml
+++ b/src/epub/text/chapter-36.xhtml
@@ -97,7 +97,7 @@
 				<p>Holabird was as much bewildered as Tubbs would have been by the ramifications of Martin’s work. What did he think he was anyway⁠—a bacteriologist or a biophysicist? But Holabird was won by the scientific world’s reception of Martin’s first important paper, on the effect of X-rays, gamma rays, and beta rays on the anti-Shiga phage. It was praised in Paris and Brussels and Cambridge as much as in New York, for its insight and for “the clarity and to perhaps be unscientifically enthusiastic, the sheer delight and style of its presentation,” as Professor Berkeley Wurtz put it; which may be indicated by quoting the first paragraph of the paper:</p>
 				<blockquote>
 					<p>In a preliminary publication, I have reported a marked qualitative destructive effect of the radiations from radium emanations on Bacteriophage-anti-Shiga. In the present paper it is shown that X-rays, gamma rays, and beta rays produce identical inactivating effects on this bacteriophage. Furthermore, a quantitative relation is demonstrated to exist between this inactivation and the radiations that produce it. The results obtained from this quantitative study permit the statement that the percentage of inactivation, as measured by determining the units of bacteriophage remaining after irradiation by gamma and beta rays of a suspension of fixed virulence, is a function of the two variables, millicuries and hours. The following equation accounts quantitatively for the experimental results obtained:</p>
-					<m:math alttext="K = (λ × log⁡(e) × u_0 / u) / E_0 × (ε − λ × t_1)">
+					<m:math alttext="K = (λ × log_e⁡(u_0 / u)) / E_0 × (ε − λ × t_1)">
 						<m:semantics>
 							<m:mrow>
 								<m:mi>K</m:mi>
@@ -106,10 +106,11 @@
 									<m:mrow>
 										<m:mi>λ</m:mi>
 										<m:mo>⁢</m:mo>
-										<m:mi>log</m:mi>
+										<m:msub>
+											<m:mi>log</m:mi>
+											<m:mi>e</m:mi>
+										</m:msub>
 										<m:mo>⁡</m:mo>
-										<m:mi>e</m:mi>
-										<m:mo>⁢</m:mo>
 										<m:mfrac>
 											<m:msub>
 												<m:mi>u</m:mi>
@@ -151,18 +152,17 @@
 											<m:apply>
 												<m:times/>
 												<m:apply>
-													<m:log/>
-													<m:ci>e</m:ci>
-												</m:apply>
-												<m:apply>
-													<m:divide/>
-													<m:ci>
-														<m:msub>
-															<m:mi>u</m:mi>
-															<m:mn>0</m:mn>
-														</m:msub>
-													</m:ci>
-													<m:ci>u</m:ci>
+													<m:ln/>
+													<m:apply>
+														<m:divide/>
+														<m:ci>
+															<m:msub>
+																<m:mi>u</m:mi>
+																<m:mn>0</m:mn>
+															</m:msub>
+														</m:ci>
+														<m:ci>u</m:ci>
+													</m:apply>
 												</m:apply>
 											</m:apply>
 										</m:apply>


### PR DESCRIPTION
Chapter 36’s equation, $K = \frac{λ\log e \frac{u_0}{u}}{E_0 \left(ε - λ t_1\right)}$, is visually ambiguous. Specifically, the logarithm in the numerator could be interpreted as `log(e) × u₀ / u` or as `log(e × u₀ / u)`. The alt text currently uses the former, but that’s definitely incorrect, because if the logarithm is of base $e$ (as it certainly would be in the context of population decline), $\log e = 1$, so it’s a redundant factor and the logarithmic equation is left with no logarithm at all.

Moving $\frac{u_0}{u}$ into the logarithm is less implausible, but leaving $e$ in there still looks odd. It’s been a very long time since I calculated population formulae, but I remember that $\log\left(e \frac{u_0}{u}\right) = 1 + \log{\left(\frac{u_0}{u}\right)}$, and having $\log e$ in there at all just didn’t smell right.

At this point, my suspicion is that either $\log e$ was understood by someone in the process of writing *Arrowsmith* to mean the logarithm base $e$ (in which case it should be updated to the more modern notation $\log_e$), or the lack of subscript on $e$ is a typo (in which case, ditto).

To get a second opinion, [I asked StackExchange](https://math.stackexchange.com/questions/4627529/what-logarithm-is-being-taken-in-this-old-novel). The opinion in the answer and most of the comments matches my own: `log(e) × u₀ / u` is obviously not right, `log(e × u₀ / u)` is highly unlikely, `log_e(u₀ / u)` is likely.